### PR TITLE
Fix Throw Error if Const Declaration isn't Initialized

### DIFF
--- a/src/main/java/org/mozilla/javascript/Parser.java
+++ b/src/main/java/org/mozilla/javascript/Parser.java
@@ -2637,7 +2637,11 @@ public class Parser {
             } else {
                 vi.setInitializer(init);
             }
-
+            if (declType == Token.CONST && init == null) {
+                // const x;
+                reportError("msg.const.decl.not.initialized");
+            }
+            System.out.println("here");
             vi.setType(declType);
             vi.setJsDocNode(jsdocNode);
             vi.setLineno(lineno);

--- a/src/main/resources/Messages.properties
+++ b/src/main/resources/Messages.properties
@@ -214,6 +214,8 @@ msg.single.statement.context=\
     SyntaxError: {0} can't appear in single-statement context
 msg.arrowfn.destructuring.unsupported=\
     SyntaxError: Arrow functions do not support parameter destructuring with default arguments
+msg.const.decl.not.initialized=\
+    SyntaxError: missing = in const declaration
 # NodeTransformer
 msg.dup.label=\
     duplicated label


### PR DESCRIPTION
It is a Syntax Error if Initializer is not present and IsConstantDeclaration of the LexicalDeclaration containing this LexicalBinding is true.