### PR TITLE
Codegen: fix slight oversight in changes to `isPrivate`

### DIFF
--- a/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
+++ b/src/main/java/org/mozilla/javascript/optimizer/Codegen.java
@@ -4908,8 +4908,7 @@ Else pass the JS object in the aReg and 0.0 in the dReg.
                         addDoubleWrap();
                     cfw.addALoad(contextLocal);
                     cfw.addALoad(variableObjectLocal);
-                    cfw.addPush(isPrivate);
-                    addScriptRuntimeInvoke("getElemFunctionAndThis", CALLABLE, OBJECT, OBJECT, CONTEXT, SCRIPTABLE, BOOLEAN);
+                    addScriptRuntimeInvoke("getElemFunctionAndThis", CALLABLE, OBJECT, OBJECT, CONTEXT, SCRIPTABLE);
                 }
 
                 break;


### PR DESCRIPTION
in the latest commit that changes `Codegen`'s `getElemFunctionAndThis` method there's a `BOOLEAN` in the param which is just not true this causes an issue with "indexed" callbacks (as i call them)

for example, this is with the current version of ChatTriggers/rhino:
<img width="699" height="210" alt="image" src="https://github.com/user-attachments/assets/441deb1f-8004-4c46-b03f-7294d886a1cf" />

you can clearly see that it's attempting to call it with a boolean value at the end

with this fix it will actually work instead of throwing:
<img width="395" height="126" alt="image" src="https://github.com/user-attachments/assets/ac702241-99e0-4789-82cf-c5818d695f59" />
